### PR TITLE
fix: add push options without double quotation marks

### DIFF
--- a/src/main/kotlin/org/jetbrains/plugins/git/custompush/actions/GitRepoAction.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/git/custompush/actions/GitRepoAction.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vcs.VcsNotifier
+import com.intellij.util.execution.ParametersListUtil
 import git4idea.GitUtil
 import git4idea.GitVcs
 import git4idea.commands.*
@@ -92,9 +93,7 @@ class GitRepoAction {
                 h.addParameters(repository.currentBranchName)
             }
             h.addParameters("--progress")
-            pushOptions.forEach { option ->
-                h.addParameters(option)
-            }
+            h.addParameters(pushOptions.flatMap { ParametersListUtil.parse(it) })
             h
         }
         return result


### PR DESCRIPTION
When adding a push option in the form of -o ci.value=, if there is a space, the final command line execution wraps it in a single pair of double quotation marks, so this behavior has been improved.

Now
```
git -c credential.helper= -c core.quotepath=false -c log.showSignature=false push origin --progress "-o ci.variable=FULL_PIPELINE=true" "-o ci.variable=TARGET=APZ"
```

After modifie
```
git -c credential.helper= -c core.quotepath=false -c log.showSignature=false push origin --progress -o ci.variable=FULL_PIPELINE=true -o ci.variable=TARGET=APZ
```